### PR TITLE
Remove subclassing of Error type

### DIFF
--- a/src/common/errors/rubic-sdk.error.ts
+++ b/src/common/errors/rubic-sdk.error.ts
@@ -1,1 +1,7 @@
-export class RubicSdkError extends Error {}
+export class RubicSdkError {
+    message?: string;
+
+    constructor(message?: string) {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
Inheriting from `Error` prevents `instanceof` comparisons due to a [breaking change by the TypeScript compiler](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work).

In practice, this makes it impossible to check which error occurred.

```ts
try {
  await trade.swap(); // attempting to execute a swap with insufficient funds
} catch (e) {
  if (e instanceof InsufficientFundsError) {
    // this block should run, but it won't
  }
}
```