### PR TITLE
Replace default API key with Rubic's

### DIFF
--- a/src/features/cross-chain/providers/via-trade-provider/constants/via-default-api-key.ts
+++ b/src/features/cross-chain/providers/via-trade-provider/constants/via-default-api-key.ts
@@ -1,5 +1,5 @@
 export const VIA_DEFAULT_CONFIG = {
-    apiKey: 'e3db93a3-ae1c-41e5-8229-b8c1ecef5583',
+    apiKey: '22498479-5d0d-44fd-b14a-cdd94e9ec5c2',
     url: 'https://router-api.via.exchange',
     timeout: 25_000
 };


### PR DESCRIPTION
Since the default API key has rate limit of 1PRS