### PR TITLE
RUBIC-963: add Klaytn, Velas and Syscoin to onChainProxy supported blockchains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rubic-sdk",
-  "version": "3.11.3-alpha-vk-0",
+  "version": "3.11.3-alpha-vk-1",
   "description": "Simplify dApp creation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rubic-sdk",
-  "version": "3.11.3-alpha-vk-1",
+  "version": "3.12.1",
   "description": "Simplify dApp creation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rubic-sdk",
-  "version": "3.11.2",
+  "version": "3.11.3-alpha-vk-0",
   "description": "Simplify dApp creation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/features/on-chain/calculation-manager/providers/common/on-chain-proxy-service/models/on-chain-proxy-supported-blockchain.ts
+++ b/src/features/on-chain/calculation-manager/providers/common/on-chain-proxy-service/models/on-chain-proxy-supported-blockchain.ts
@@ -20,7 +20,10 @@ export const onChainProxySupportedBlockchains = [
     BLOCKCHAIN_NAME.BOBA,
     BLOCKCHAIN_NAME.KAVA,
     BLOCKCHAIN_NAME.BITGERT,
-    BLOCKCHAIN_NAME.METIS
+    BLOCKCHAIN_NAME.METIS,
+    BLOCKCHAIN_NAME.KLAYTN,
+    BLOCKCHAIN_NAME.SYSCOIN,
+    BLOCKCHAIN_NAME.VELAS
 ] as const;
 
 export type OnChainProxySupportedBlockchain = typeof onChainProxySupportedBlockchains[number];

--- a/src/features/on-chain/calculation-manager/providers/common/on-chain-proxy-service/models/on-chain-proxy-supported-blockchain.ts
+++ b/src/features/on-chain/calculation-manager/providers/common/on-chain-proxy-service/models/on-chain-proxy-supported-blockchain.ts
@@ -23,7 +23,8 @@ export const onChainProxySupportedBlockchains = [
     BLOCKCHAIN_NAME.METIS,
     BLOCKCHAIN_NAME.KLAYTN,
     BLOCKCHAIN_NAME.SYSCOIN,
-    BLOCKCHAIN_NAME.VELAS
+    BLOCKCHAIN_NAME.VELAS,
+    BLOCKCHAIN_NAME.OASIS
 ] as const;
 
 export type OnChainProxySupportedBlockchain = typeof onChainProxySupportedBlockchains[number];


### PR DESCRIPTION
Added Klaytn, Velas, Syscoin and Oasis to onChainProxy supported blockchains